### PR TITLE
fix: redirect-paypro-to-thank-you is called as a POST request

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -117,7 +117,7 @@ apiRouter.post('/paddle-webhook', lambdaWrapper('paddle-webhook'));
 apiRouter.post('/paypro-webhook', lambdaWrapper('paypro-webhook'));
 
 apiRouter.get('/redirect-to-checkout', lambdaWrapper('redirect-to-checkout'));
-apiRouter.get('/redirect-paypro-to-thank-you', lambdaWrapper('redirect-paypro-to-thank-you'));
+apiRouter.post('/redirect-paypro-to-thank-you', lambdaWrapper('redirect-paypro-to-thank-you'));
 
 const sendCodeRateLimiter = rateLimit(RATE_LIMIT_PARAMS);
 apiRouter.post('/auth/send-code', sendCodeRateLimiter, lambdaWrapper('auth/send-code'));


### PR DESCRIPTION
After I purchased the Pro license, I got the following error in the browser checkout: 

```
Cannot POST /api/redirect-paypro-to-thank-you
```

It seems like a simple patch since the API is listening to a GET instead of a POST